### PR TITLE
Allow blank primary key values when appropriate

### DIFF
--- a/lib/dm-accepts_nested_attributes/resource.rb
+++ b/lib/dm-accepts_nested_attributes/resource.rb
@@ -330,7 +330,7 @@ module DataMapper
       #
       # @return [void]
       def assert_hash_or_array_of_hashes(param_name, value)
-       if value.is_a?(Hash)
+        if value.is_a?(Hash)
           unless value.values.all? { |a| a.is_a?(Hash) }
             raise ArgumentError,
                   "+#{param_name}+ should be a Hash of Hashes or Array " +

--- a/lib/dm-accepts_nested_attributes/resource.rb
+++ b/lib/dm-accepts_nested_attributes/resource.rb
@@ -360,7 +360,7 @@ module DataMapper
       #   A collection of attribute hashes.
       def normalize_attributes_collection(attributes)
         if attributes.is_a?(Hash)
-          attributes.map { |_, attributes| attributes }
+          attributes.map { |_, attrs| attrs }
         else
           attributes
         end


### PR DESCRIPTION
Blank key values were previously rejected outright, even if the `Property` for which they were destined allows `#blank?`, or `nil`, or is a `Boolean`, which, of course, accepts `false` as a valid value (one of only two valid values!). 

`false`, of course, also happens to be `#blank?`, which meant that you could previously never set a key to `false`.

Current tests do still pass, however this deserves some additional test coverage to prevent future regression. I have not added the deserved tests; this patch works in my app, which is all I have time to verify right now.
