### PR TITLE
add the delete_key option to define it in nested options

### DIFF
--- a/lib/data_mapper/nested_attributes/acceptor.rb
+++ b/lib/data_mapper/nested_attributes/acceptor.rb
@@ -20,6 +20,7 @@ module DataMapper
 
       attr_reader :relationship
       attr_reader :assignment_guard
+      attr_reader :delete_key
       attr_writer :assignment_factory
 
       def initialize(relationship, options)
@@ -27,6 +28,7 @@ module DataMapper
         @allow_destroy    = !!options.fetch(:allow_destroy, false)
         guard_factory     = options.fetch(:guard_factory) { Assignment::Guard }
         @assignment_guard = guard_factory.for(options.fetch(:reject_if, nil))
+        @delete_key = option.feth(:delete_key, :_delete).to_sym
       end
 
       def allow_destroy?
@@ -148,10 +150,6 @@ module DataMapper
         else
           resource.model.key.map { |property| property.name } << delete_key
         end
-      end
-
-      def delete_key
-        :_delete
       end
 
       # Determines whether the given attributes hash contains a truthy :_delete key.

--- a/test/data_mapper/nested_attributes/acceptor/initialize_spec.rb
+++ b/test/data_mapper/nested_attributes/acceptor/initialize_spec.rb
@@ -35,5 +35,14 @@ module DataMapper
       end
     end
 
+    describe 'with :delete_key => :_destroy' do
+      let(:options) { { :delete_key => :_destroy } }
+
+      it 'captures the :delete_key option as #delete_key' do
+        assert_same delete_key, :_destroy
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
In ActiveRecord the delete_key is `_destroy` and in this gem the delete_key is `_delete` be default.

This commit use the new refactor to define this key directly like option in `accepts_nested_attributes_for` method. 

It can be really great to have this compatibility.
